### PR TITLE
Improve Default Color Handling

### DIFF
--- a/RadialMenuControl/Components/RadialMenuButton.xaml.cs
+++ b/RadialMenuControl/Components/RadialMenuButton.xaml.cs
@@ -1,3 +1,5 @@
+using System.Collections.Generic;
+
 namespace RadialMenuControl.Components
 {
     using UserControl;
@@ -6,6 +8,7 @@ namespace RadialMenuControl.Components
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Controls;
     using Windows.UI.Xaml.Media;
+    using System.Reflection;
 
     public partial class RadialMenuButton : Button
     {
@@ -118,78 +121,78 @@ namespace RadialMenuControl.Components
         
         // Inner Arc Colors
         public static readonly DependencyProperty InnerNormalColorProperty =
-            DependencyProperty.Register("InnerNormalColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 255, 255, 255)));
+            DependencyProperty.Register("InnerNormalColor", typeof(Color?), typeof(RadialMenuButton), null);
 
         public static readonly DependencyProperty InnerHoverColorProperty =
-            DependencyProperty.Register("InnerHoverColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 245, 236, 243)));
+            DependencyProperty.Register("InnerHoverColor", typeof(Color?), typeof(RadialMenuButton), null);
 
         public static readonly DependencyProperty InnerTappedColorProperty =
-            DependencyProperty.Register("InnerTappedColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 237, 234, 236)));
+            DependencyProperty.Register("InnerTappedColor", typeof(Color?), typeof(RadialMenuButton), null);
 
         public static readonly DependencyProperty InnerReleasedColorProperty =
-            DependencyProperty.Register("InnerReleasedColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 192, 157, 190)));
+            DependencyProperty.Register("InnerReleasedColor", typeof(Color?), typeof(RadialMenuButton), null);
 
-        public Color InnerHoverColor
+        public Color? InnerHoverColor
         {
-            get { return (Color)GetValue(InnerHoverColorProperty); }
+            get { return (Color?)GetValue(InnerHoverColorProperty); }
             set { SetValue(InnerHoverColorProperty, value); }
         }
 
-        public Color InnerNormalColor
+        public Color? InnerNormalColor
         {
-            get { return (Color)GetValue(InnerNormalColorProperty); }
+            get { return (Color?)GetValue(InnerNormalColorProperty); }
             set { SetValue(InnerNormalColorProperty, value); }
         }
 
-        public Color InnerTappedColor
+        public Color? InnerTappedColor
         {
-            get { return (Color)GetValue(InnerTappedColorProperty); }
+            get { return (Color?)GetValue(InnerTappedColorProperty); }
             set { SetValue(InnerTappedColorProperty, value); }
         }
-        public Color InnerReleasedColor
+        public Color? InnerReleasedColor
         {
-            get { return (Color)GetValue(InnerReleasedColorProperty); }
+            get { return (Color?)GetValue(InnerReleasedColorProperty); }
             set { SetValue(InnerReleasedColorProperty, value); }
         }
 
         // Outer Arc Colors
         public static readonly DependencyProperty OuterNormalColorProperty =
-            DependencyProperty.Register("OuterNormalColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 128, 57, 123)));
+            DependencyProperty.Register("OuterNormalColor", typeof(Color?), typeof(RadialMenuButton), null);
 
         public static readonly DependencyProperty OuterDisabledColorProperty =
-            DependencyProperty.Register("OuterDisabledColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 237, 211, 236)));
+            DependencyProperty.Register("OuterDisabledColor", typeof(Color?), typeof(RadialMenuButton), null);
 
         public static readonly DependencyProperty OuterHoverColorProperty =
-            DependencyProperty.Register("OuterHoverColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 155, 79, 150)));
+            DependencyProperty.Register("OuterHoverColor", typeof(Color?), typeof(RadialMenuButton), null);
 
         public static readonly DependencyProperty OuterTappedColorProperty =
-            DependencyProperty.Register("OuterTappedColor", typeof(Color), typeof(RadialMenuButton), new PropertyMetadata(Color.FromArgb(255, 104, 41, 100)));
+            DependencyProperty.Register("OuterTappedColor", typeof(Color?), typeof(RadialMenuButton), null);
         
         // CustomMenu
         public static readonly DependencyProperty CustomMenuProperty =
             DependencyProperty.Register("Submenu", typeof(MenuBase), typeof(RadialMenuButton), null);
             
-        public Color OuterHoverColor
+        public Color? OuterHoverColor
         {
-            get { return (Color)GetValue(OuterHoverColorProperty); }
+            get { return (Color?)GetValue(OuterHoverColorProperty); }
             set { SetValue(OuterHoverColorProperty, value); }
         }
 
-        public Color OuterNormalColor
+        public Color? OuterNormalColor
         {
-            get { return (Color)GetValue(OuterNormalColorProperty); }
+            get { return (Color?)GetValue(OuterNormalColorProperty); }
             set { SetValue(OuterNormalColorProperty, value); }
         }
 
-        public Color OuterDisabledColor
+        public Color? OuterDisabledColor
         {
-            get { return (Color)GetValue(OuterDisabledColorProperty); }
+            get { return (Color?)GetValue(OuterDisabledColorProperty); }
             set { SetValue(OuterDisabledColorProperty, value); }
         }
 
-        public Color OuterTappedColor
+        public Color? OuterTappedColor
         {
-            get { return (Color)GetValue(OuterTappedColorProperty); }
+            get { return (Color?)GetValue(OuterTappedColorProperty); }
             set { SetValue(OuterTappedColorProperty, value); }
         }
 
@@ -250,6 +253,22 @@ namespace RadialMenuControl.Components
         public bool HasOuterArcEvents()
         {
             return (OuterArcPressedEvent != null || OuterArcReleasedEvent != null);
+        }
+
+        /// <summary>
+        /// Allows the use of key/value pairs to set the colors
+        /// </summary>
+        /// <param name="colors"></param>
+        public void SetColors(Dictionary<string, Color> colors)
+        {
+            foreach (var colorVariable in colors)
+            {
+                if (this.GetType().GetProperty(colorVariable.Key) != null)
+                {
+                    var prop = this.GetType().GetProperty(colorVariable.Key);
+                    prop.SetValue(this, colorVariable.Value);
+                }
+            }
         }
 
         // SubMenu

--- a/RadialMenuControl/Themes/Colors.cs
+++ b/RadialMenuControl/Themes/Colors.cs
@@ -10,6 +10,7 @@ namespace RadialMenuControl.Themes
         public static Color InnerNormalColor = Color.FromArgb(255, 255, 255, 255),
                             InnerHoverColor = Color.FromArgb(255, 245, 236, 243),
                             InnerTappedColor = Color.FromArgb(255, 237, 234, 236),
+                            InnerReleasedColor = Color.FromArgb(255, 192, 157, 190),
                             OuterNormalColor = Color.FromArgb(255, 128, 57, 123),
                             OuterDisabledColor = Color.FromArgb(255, 237, 211, 236),
                             OuterHoverColor = Color.FromArgb(255, 155, 79, 150),

--- a/RadialMenuControl/UserControl/Pie.xaml.cs
+++ b/RadialMenuControl/UserControl/Pie.xaml.cs
@@ -15,41 +15,12 @@ namespace RadialMenuControl.UserControl
     public partial class Pie : UserControl, INotifyPropertyChanged
     {
         private readonly ObservableCollection<PieSlice> _pieSlices = new ObservableCollection<PieSlice>();
-
         public event PropertyChangedEventHandler PropertyChanged;
 
         // Pass in the original RadialMenu
         public RadialMenu SourceRadialMenu;
         public static readonly DependencyProperty SourceRadialMenuProperty =
             DependencyProperty.Register("SourceRadialMenu", typeof(RadialMenu), typeof(Pie), null);
-
-        private Color _backgroundColor = Colors.White;
-        public Color BackgroundColor
-        {
-            get { return _backgroundColor; }
-            set { SetField(ref _backgroundColor, value); }
-        }
-
-        private Color _backgroundHighlightColor = DefaultColors.BackgroundHighlightColor;
-        public Color BackgroundHighlightColor
-        {
-            get { return _backgroundHighlightColor; }
-            set { SetField(ref _backgroundHighlightColor, value); }
-        }
-
-        private Color _foregroundColor = DefaultColors.ForegroundColor;
-        public Color ForegroundColor
-        {
-            get { return _foregroundColor; }
-            set { SetField(ref _foregroundColor, value); }
-        }
-
-        private Color _highlightColor = DefaultColors.HighlightColor;
-        public Color HighlightColor
-        {
-            get { return _highlightColor; }
-            set { SetField(ref _highlightColor, value); }
-        }
 
         private double _startAngle;
         public double StartAngle
@@ -176,14 +147,14 @@ namespace RadialMenuControl.UserControl
                     Height = Height,
                     Width = Width,
                     // The defaults below use OneNote-like purple colors
-                    InnerNormalColor = slice.InnerNormalColor,
-                    InnerHoverColor = slice.InnerHoverColor,
-                    InnerTappedColor = slice.InnerTappedColor,
-                    InnerReleasedColor = slice.InnerReleasedColor,
-                    OuterNormalColor = slice.OuterNormalColor,
-                    OuterDisabledColor = slice.OuterDisabledColor,
-                    OuterHoverColor = slice.OuterHoverColor,
-                    OuterTappedColor = slice.OuterTappedColor,
+                    InnerNormalColor = slice.InnerNormalColor ?? SourceRadialMenu.ButtonDefaultColors["InnerNormalColor"],
+                    InnerHoverColor = slice.InnerHoverColor ?? SourceRadialMenu.ButtonDefaultColors["InnerHoverColor"],
+                    InnerTappedColor = slice.InnerTappedColor ?? SourceRadialMenu.ButtonDefaultColors["InnerTappedColor"],
+                    InnerReleasedColor = slice.InnerReleasedColor ?? SourceRadialMenu.ButtonDefaultColors["InnerReleasedColor"],
+                    OuterNormalColor = slice.OuterNormalColor ?? SourceRadialMenu.ButtonDefaultColors["OuterNormalColor"],
+                    OuterDisabledColor = slice.OuterDisabledColor ?? SourceRadialMenu.ButtonDefaultColors["OuterDisabledColor"],
+                    OuterHoverColor = slice.OuterHoverColor ?? SourceRadialMenu.ButtonDefaultColors["OuterHoverColor"],
+                    OuterTappedColor = slice.OuterTappedColor ?? SourceRadialMenu.ButtonDefaultColors["OuterTappedColor"],
                     // Label
                     IconSize = slice.IconSize,
                     Icon = slice.Icon,

--- a/RadialMenuControl/UserControl/RadialMenu.xaml.cs
+++ b/RadialMenuControl/UserControl/RadialMenu.xaml.cs
@@ -1,4 +1,6 @@
 ﻿using System;
+using System.Linq;
+using Windows.UI;
 using Windows.UI.Xaml.Controls.Primitives;
 using Windows.UI.Xaml.Input;
 using Windows.UI.Xaml.Media.Animation;
@@ -8,6 +10,7 @@ namespace RadialMenuControl.UserControl
     using Components;
     using Shims;
     using Extensions;
+    using Themes;
     using System.Collections.Generic;
     using Windows.UI.Xaml;
     using Windows.UI.Xaml.Media;
@@ -32,6 +35,29 @@ namespace RadialMenuControl.UserControl
             {
                 SetField(ref _startAngle, value);
                 Pie.StartAngle = value;
+            }
+        }
+
+        private Dictionary<string, Color> _buttonDefaultColors = new Dictionary<string, Color>()
+        {
+            { "OuterNormalColor", DefaultColors.OuterNormalColor },
+            { "OuterHoverColor", DefaultColors.OuterHoverColor },
+            { "OuterDisabledColor", DefaultColors.OuterDisabledColor },
+            { "OuterTappedColor", DefaultColors.OuterTappedColor },
+            { "InnerNormalColor", DefaultColors.InnerNormalColor },
+            { "InnerHoverColor", DefaultColors.InnerHoverColor },
+            { "InnerTappedColor", DefaultColors.InnerTappedColor },
+            { "InnerReleasedColor", DefaultColors.InnerReleasedColor },
+        };
+        public Dictionary<string, Color> ButtonDefaultColors
+        {
+            get { return _buttonDefaultColors; }
+            set
+            {
+                foreach (var colorPair in value.Where(colorPair => _buttonDefaultColors.ContainsKey(colorPair.Key)))
+                {
+                    _buttonDefaultColors[colorPair.Key] = colorPair.Value;
+                }
             }
         }
 

--- a/RadialMenuDemo/Melbourne.xaml.cs
+++ b/RadialMenuDemo/Melbourne.xaml.cs
@@ -27,18 +27,23 @@ namespace RadialMenuDemo
     {
         public Melbourne()
         {
+            var buttonColors = new Dictionary<string, Color>()
+            {
+                { "OuterNormalColor", Color.FromArgb(255, 56, 55, 57) },
+                { "OuterHoverColor", Color.FromArgb(255, 70, 102, 102) },
+                { "OuterDisabledColor", Color.FromArgb(255, 96, 139, 139) },
+                { "InnerNormalColor", Colors.White },
+                { "InnerHoverColor", Color.FromArgb(255, 227, 235, 235) },
+                { "InnerDisabledColor", Color.FromArgb(255, 227, 235, 235) },
+                { "InnerReleasedColor", Color.FromArgb(255, 227, 235, 235) },
+            };
+
             var eraser = new RadialMenuButton
             {
                 Label = "Eraser",
                 Icon = "",
                 IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                Type = RadialMenuButton.ButtonType.Radio,
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                Type = RadialMenuButton.ButtonType.Radio
             };
 
             var pan = new RadialMenuButton
@@ -47,12 +52,6 @@ namespace RadialMenuDemo
                 Icon = "",
                 IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
                 Type = RadialMenuButton.ButtonType.Radio,
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235),
                 Submenu = new RadialMenu()
             };
 
@@ -74,79 +73,43 @@ namespace RadialMenuDemo
                 Label = "Pen",
                 Icon = "",
                 IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                Type = RadialMenuButton.ButtonType.Radio,
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                Type = RadialMenuButton.ButtonType.Radio
             };
             var pen2 = new RadialMenuButton
             {
                 Label = "Pen",
                 Icon = "",
                 IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                Type = RadialMenuButton.ButtonType.Radio,
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                Type = RadialMenuButton.ButtonType.Radio
             };
             var add = new RadialMenuButton
             {
                 Label = "Add",
                 Icon = "",
-                IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                IconFontFamily = new FontFamily("Segoe MDL2 Assets")
             };
             var insert = new RadialMenuButton
             {
                 Label = "Insert",
                 Icon = "",
-                IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                IconFontFamily = new FontFamily("Segoe MDL2 Assets")
             };
             var highlight = new RadialMenuButton
             {
                 Label = "Highlight",
                 Icon = "",
-                IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                Type = RadialMenuButton.ButtonType.Radio,
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                IconFontFamily = new FontFamily("Segoe MDL2 Assets")
             };
             var undo = new RadialMenuButton
             {
                 Label = "Undo",
                 Icon = "",
-                IconFontFamily = new FontFamily("Segoe MDL2 Assets"),
-                OuterNormalColor = Color.FromArgb(255, 56, 55, 57),
-                OuterHoverColor = Color.FromArgb(255, 70, 102, 102),
-                OuterDisabledColor = Color.FromArgb(255, 96, 139, 139),
-                InnerNormalColor = Colors.White,
-                InnerHoverColor = Color.FromArgb(255, 227, 235, 235),
-                InnerReleasedColor = Color.FromArgb(255, 227, 235, 235)
+                IconFontFamily = new FontFamily("Segoe MDL2 Assets")
             };
 
             this.InitializeComponent();
 
+            MyRadialMenu.ButtonDefaultColors = buttonColors;
             MyRadialMenu.AddButton(eraser);
             MyRadialMenu.AddButton(pan);
             MyRadialMenu.AddButton(pen1);


### PR DESCRIPTION
This PR enables users of the menu to set colors using a dictionary on
the whole menu or individual buttons, thereby making custom colors _a lot_ less cumbersome.
